### PR TITLE
[BUGFIX] Fix NOR crash on exit after removing Funkin' Remnants

### DIFF
--- a/scripts/utils/LastRemnantsCharHelper.hxc
+++ b/scripts/utils/LastRemnantsCharHelper.hxc
@@ -9,13 +9,22 @@ class LastRemnantsCharHelper extends Module
     super('lastRemnantsCharHelper', 0);
   }
 
+  var dontActivate:Bool;
+
+  public function onDestroy(event:ScriptEvent):Void
+  {
+    dontActivate = true; // Dont allow the onExit code to run
+  }
+  
   public function onCreate(event:ScriptEvent):Void
   {
     RemnantsContentUtil.loadLastRemnantsChar();
 
+    dontActivate = false;
     if (!ModStore.stores.exists('lastRemnantsCharHelperInit'))
     {
       Application.current.onExit.add((exitCode) -> {
+        if (dontActivate ?? true) return; // No more NOR
         RemnantsContentUtil.saveLastRemnantsChar();
         trace('Saved Remnants(?) Char!');
       });


### PR DESCRIPTION
This PR fixes a possible NOR that could happen when trying to close the game after disabling / removing Funkin' Remnants