### PR TITLE
[BUGFIX] Fix NOR crash on exit after removing Funkin' Remnants... Again...

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -2,7 +2,6 @@ name: Mobile Compression
 
 on:
   push:
-    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -15,50 +14,57 @@ jobs:
 
     steps:
       - name: Download Source Code
-        uses: FunkinCrew/ci-checkout@v7.3.3
+        uses: actions/checkout@main
+        with:
+          path: 'repo'
 
-      - uses: FunkinCrew/ci-haxe@v3
+      - uses: krdlab/setup-haxe@master
         with:
           haxe-version: 4.3.7
 
       - name: Install ASTC Compressor
-        run: haxelib --quiet --always git astc-compressor https://github.com/TechnikTil/astc-compressor chore/kill-neko
+        run: haxelib --quiet --always git astc-compressor https://github.com/KarimAkra/astc-compressor develop
+        working-directory: repo
 
       - name: Retrieve Asset Cache
         id: fetch-asset-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@main
         with:
-          path: astc-textures/**
+          path: repo/astc-textures/**
           key: asset-cache
 
       - name: Run ASTC Compressor
         run: haxelib run astc-compressor compress-from-json -json ./astc-compression-data.json
+        working-directory: repo
 
       - name: Save Asset Cache
         id: save-asset-cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@main
         with:
-          path: astc-textures/**
-          key: asset-cache
+          path: repo/astc-textures/**
+          key: ${{ steps.fetch-asset-cache.outputs.cache-primary-key }}
 
       - name: Overwrite PNGs with ASTCs
         run: |
           find "astc-textures/" -name "*.astc" -type f | while read -r file; do
+            echo "$file"
             normalFileLoc="${file#astc-textures/}"
+            normalFilePng="${normalFileLoc%.*}.png"
 
-            mv "$file" "$normalFileLoc"
-            rm "${normalFileLoc%.*}.png"
+            if [ -f "$normalFilePng" ]; then
+              mv "$file" "$normalFileLoc"
+              rm "${normalFilePng}"
+            else
+              rm "$file"
+            fi
           done
+        working-directory: repo
 
-      - name: Push ASTC Files to `mobile` branch
-        uses: stefanzweifel/git-auto-commit-action@v6
+      - name: Upload Mobile Artifact
+        uses: actions/upload-artifact@main
         with:
-          commit_message: Compress Images using ASTC
-          branch: mobile
-          push_options: '--force'
+          name: mobile
+          path: |
+            repo/
+            !repo/astc-textures/
 
-          file_pattern: '*.astc *.png'
-
-          commit_user_name: github-actions[bot]
-          commit_user_email: 41898282+github-actions[bot]@users.noreply.github.com
-          commit_author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -31,15 +31,16 @@ jobs:
         uses: actions/cache/restore@main
         with:
           path: repo/astc-textures/**
-          key: asset-cache
+          key: astc-${{ hashFiles('repo/**.png') }}
+          restore-keys: astc-
 
       - name: Run ASTC Compressor
         run: haxelib run astc-compressor compress-from-json -json ./astc-compression-data.json
         working-directory: repo
 
       - name: Save Asset Cache
-        id: save-asset-cache
         uses: actions/cache/save@main
+        if: steps.fetch-asset-cache.outputs.cache-hit != 'true'
         with:
           path: repo/astc-textures/**
           key: ${{ steps.fetch-asset-cache.outputs.cache-primary-key }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 <div align='center'>
 <img src="images/titleScreen/remnantsLogo.png" width="500">
+
 # Funkin' Remnants
 A Friday Night Funkin' Remix Mod with a cool style and references to Early Funkin' Content.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+<div align='center'>
+<img src="images/titleScreen/remnantsLogo.png" width="500">
 # Funkin' Remnants
 A Friday Night Funkin' Remix Mod with a cool style and references to Early Funkin' Content.
 
 ## Download
 [Get it on Gamebanana!](https://gamebanana.com/mods/653229)
+</div>

--- a/scripts/utils/LastRemnantsCharHelper.hxc
+++ b/scripts/utils/LastRemnantsCharHelper.hxc
@@ -1,6 +1,8 @@
 import funkin.modding.module.Module;
 import funkin.modding.ModStore;
 import lime.app.Application;
+import funkin.play.PlayState;
+import flixel.util.FlxTimer;
 
 class LastRemnantsCharHelper extends Module
 {
@@ -9,25 +11,41 @@ class LastRemnantsCharHelper extends Module
     super('lastRemnantsCharHelper', 0);
   }
 
-  var dontActivate:Bool;
+  var shouldSave:Bool;
+  var timer:FlxTimer;
 
-  public function onDestroy(event:ScriptEvent):Void
+  public function onDestroy(event:ScriptEvent)
   {
-    dontActivate = true; // Dont allow the onExit code to run
+    super.onDestroy(event);
+    if (PlayState.instance != null)
+    {
+      if (timer?.active ?? false)
+      {
+        shouldSave = false;
+        timer?.cancel();
+        return;  
+      }
+      timer = FlxTimer.wait(0.1, () -> {timer = null;});
+    }
+    else
+    {
+      shouldSave = false;
+    }
   }
-  
+
   public function onCreate(event:ScriptEvent):Void
   {
     RemnantsContentUtil.loadLastRemnantsChar();
 
-    dontActivate = false;
+    shouldSave = true;
+
     if (!ModStore.stores.exists('lastRemnantsCharHelperInit'))
     {
-      Application.current.onExit.add((exitCode) -> {
-        if (dontActivate ?? true) return; // No more NOR
+      Application.current.window.onClose.add(() -> {
+        if (!(shouldSave ?? false)) return;
         RemnantsContentUtil.saveLastRemnantsChar();
         trace('Saved Remnants(?) Char!');
-      });
+      }, false, 1000);
       ModStore.register('lastRemnantsCharHelperInit');
     }
   }


### PR DESCRIPTION
This PR re-fixes a possible NOR that could happen when trying to close the game after disabling / removing Funkin' Remnants since 0.8.4 doesn't properly call `onExit` anymore. This also adds a check to make sure it doesn't get destroyed when leaving the PlayState.